### PR TITLE
added header to bin/ScalarTree.cc to get it to compile

### DIFF
--- a/bin/ScalarTree.cc
+++ b/bin/ScalarTree.cc
@@ -13,6 +13,7 @@
 #include "TString.h"
 #include "TFile.h"
 #include "TTree.h"
+#include <stdint.h>
 
 
 int ScalarTree (TString const InFileName, TString const OutFileName)


### PR DESCRIPTION
Hi Dean (or Phil),

I needed to add an include statement to get a particular file to compile on the Rutgers hexfarm in CMSSW_5_3_9.  I don't think it hurts to add it, so you might think about including it by merging my pull request.  Thanks!
