### PR TITLE
Track desynchronized event numbers in channels

### DIFF
--- a/interface/PLTBinaryFileReader.h
+++ b/interface/PLTBinaryFileReader.h
@@ -29,9 +29,9 @@ class PLTBinaryFileReader
 
 
     int  convPXL (int);
-    bool DecodeSpyDataFifo (uint32_t, std::vector<PLTHit*>&);
-    int  ReadEventHits (std::vector<PLTHit*>&, unsigned long&, uint32_t&, uint32_t&);
-    int  ReadEventHits (std::ifstream&, std::vector<PLTHit*>&, unsigned long&, uint32_t&, uint32_t&);
+    bool DecodeSpyDataFifo (uint32_t, std::vector<PLTHit*>&, std::vector<int>&);
+    int  ReadEventHits (std::vector<PLTHit*>&, unsigned long&, uint32_t&, uint32_t&, std::vector<int>&);
+    int  ReadEventHits (std::ifstream&, std::vector<PLTHit*>&, unsigned long&, uint32_t&, uint32_t&, std::vector<int>&);
     int  ReadEventHitsText (std::ifstream&, std::vector<PLTHit*>&, unsigned long&, uint32_t&, uint32_t&);
 
     void ReadPixelMask (std::string const);

--- a/interface/PLTEvent.h
+++ b/interface/PLTEvent.h
@@ -91,6 +91,8 @@ class PLTEvent : public PLTTracking
       return fGainCal.GetHardwareID(ch);
     }
 
+    std::vector<int>& getDesyncChannels(void) { return fDesyncChannels; }
+
     std::string ReadableTime();
 
   private:
@@ -99,6 +101,7 @@ class PLTEvent : public PLTTracking
     unsigned long fEvent;
     uint32_t fTime;
     uint32_t fBX;
+    std::vector<int> fDesyncChannels;
 
     PLTGainCal fGainCal;
     PLTBinaryFileReader fBinFile;

--- a/src/PLTEvent.cc
+++ b/src/PLTEvent.cc
@@ -138,6 +138,8 @@ void PLTEvent::Clear ()
   fHits.clear();
   fPlanes.clear();
   fTelescopes.clear();
+
+  fDesyncChannels.clear();
 }
 
 
@@ -266,7 +268,7 @@ int PLTEvent::GetNextEvent ()
   Clear();
 
   // The number we'll return.. number of hits, or -1 for end
-  int ret = fBinFile.ReadEventHits(fHits, fEvent, fTime, fBX);
+  int ret = fBinFile.ReadEventHits(fHits, fEvent, fTime, fBX, fDesyncChannels);
   if (ret < 0) {
     return ret;
   }


### PR DESCRIPTION
A simple change to PLTEvent and PLTBinaryFileReader to actually do something if event number errors are encountered in the binary data -- they will be added to a vector tracking the desynchronized channels, which can be accessed using GetDesyncChannels().