### PR TITLE
Add error decoding to PLTEvent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ ConvertGainCoefs
 DeanTextToBinary
 DetectFailure
 DoubleColumnMC
+DumpErrors
 dumpPixffil
 dumpPixffil_orig
 FindFilledBX

--- a/bin/DumpErrors.cc
+++ b/bin/DumpErrors.cc
@@ -1,0 +1,69 @@
+////////////////////////////////////////////////////////////////////
+//
+// DumpErrors
+// Paul Lujan
+// April 19, 2017
+//
+// A simple script to test the new PLTError functionality by
+// dumping the errors in an input file.
+//
+////////////////////////////////////////////////////////////////////
+
+#include <iostream>
+#include <iomanip>
+//#/include <string>
+//#include <map>
+//#include <numeric>
+
+#include "PLTEvent.h"
+
+// FUNCTION DEFINITIONS HERE
+
+// CONSTANTS HERE
+
+// CODE BELOW
+
+int DumpErrors(const std::string DataFileName) {
+  // Set up the PLTEvent reader
+  PLTEvent Event(DataFileName);
+  Event.SetPlaneClustering(PLTPlane::kClustering_NoClustering, PLTPlane::kFiducialRegion_All);
+  Event.SetPlaneFiducialRegion(PLTPlane::kFiducialRegion_All);
+  Event.SetTrackingAlgorithm(PLTTracking::kTrackingAlgorithm_NoTracking);
+
+  // Loop over all events in file
+  for (int ientry = 0; Event.GetNextEvent() >= 0; ++ientry) {
+    if (ientry % 50000 == 0) {
+      int nsec = Event.Time()/1000;
+      int hr = nsec/3600;
+      int min = (nsec-(hr*3600))/60;
+      int sec = nsec % 60;
+      std::cout << "Processing event: " << ientry << " at " << std::setfill('0') << std::setw(2)
+		<< hr << ":" << std::setw(2) << min << ":" << std::setw(2) << sec << "."
+		<< std::setw(3) << Event.Time()%1000 << std::endl;
+    }
+    //if (ientry > 10000) break;
+
+    const std::vector<PLTError>& errors = Event.GetErrors();
+    if (errors.size() > 0) {
+      std::cout << "Event " << Event.EventNumber() << " number of errors: " << errors.size() << std::endl;
+      for (std::vector<PLTError>::const_iterator it = errors.begin(); it != errors.end(); ++it) {
+	it->Print();
+      }
+    }
+  }
+
+  return 0;
+}
+
+
+int main (int argc, const char* argv[]) {
+  if (argc != 2) {
+    std::cerr << "Usage: " << argv[0] << " [DataFile.dat]" << std::endl;
+    return 1;
+  }
+
+  std::string const DataFileName = argv[1];
+  DumpErrors(DataFileName);
+
+  return 0;
+}

--- a/interface/PLTBinaryFileReader.h
+++ b/interface/PLTBinaryFileReader.h
@@ -12,7 +12,7 @@
 #include "PLTHit.h"
 #include "PLTPlane.h"
 #include "PLTGainCal.h"
-
+#include "PLTError.h"
 
 class PLTBinaryFileReader
 {
@@ -29,9 +29,9 @@ class PLTBinaryFileReader
 
 
     int  convPXL (int);
-    bool DecodeSpyDataFifo (uint32_t, std::vector<PLTHit*>&, std::vector<int>&);
-    int  ReadEventHits (std::vector<PLTHit*>&, unsigned long&, uint32_t&, uint32_t&, std::vector<int>&);
-    int  ReadEventHits (std::ifstream&, std::vector<PLTHit*>&, unsigned long&, uint32_t&, uint32_t&, std::vector<int>&);
+    bool DecodeSpyDataFifo (uint32_t, std::vector<PLTHit*>&, std::vector<PLTError>&, std::vector<int>&);
+    int  ReadEventHits (std::vector<PLTHit*>&, std::vector<PLTError>&, unsigned long&, uint32_t&, uint32_t&, std::vector<int>&);
+    int  ReadEventHits (std::ifstream&, std::vector<PLTHit*>&, std::vector<PLTError>&, unsigned long&, uint32_t&, uint32_t&, std::vector<int>&);
     int  ReadEventHitsText (std::ifstream&, std::vector<PLTHit*>&, unsigned long&, uint32_t&, uint32_t&);
 
     void ReadPixelMask (std::string const);

--- a/interface/PLTError.h
+++ b/interface/PLTError.h
@@ -31,12 +31,12 @@ public:
   ~PLTError();
 
   // Getters
-  uint32_t GetChannel() { return fChannel; }
-  ErrorType GetErrorType() { return fErrorType; }
-  uint32_t GetErrorDetails() { return fErrorDetails; }
+  uint32_t GetChannel() const { return fChannel; }
+  ErrorType GetErrorType() const { return fErrorType; }
+  uint32_t GetErrorDetails() const { return fErrorDetails; }
 
   // Print out detailed error information
-  void Print(void);
+  void Print(void) const;
 
 private:
   uint32_t fChannel;

--- a/interface/PLTError.h
+++ b/interface/PLTError.h
@@ -1,0 +1,47 @@
+#ifndef GUARD_PLTError_h
+#define GUARD_PLTError_h
+
+// A very simple container class to hold information about a single
+// error reported in the data stream. There are three fields:
+// 1) channel: FED channel number that the error is in
+// 2) errorType: what kind of error it is
+// 3) errorDetails: more information on the error:
+//   -- for time out, the time out counter
+//   -- for event number error, the TBM event number
+//   -- for near full, the bit field showing the specific FIFO information
+//   -- for FED trailer error, the 4-bit nibble with the individual error bits
+//   -- for TBM error, the 8-bit word with the individual error bits
+// See PLTError::Print() for a little more details on what the error bits mean.
+
+#include <stdint.h>
+
+typedef enum ErrorTypeEnum {
+  kTimeOut,
+  kEventNumberError,
+  kNearFull,
+  kFEDTrailerError,
+  kTBMError,
+  kUnknownError
+} ErrorType;
+
+class PLTError {
+public:
+  PLTError(uint32_t channel, ErrorType errorType, uint32_t errorDetails);
+  ~PLTError();
+
+  // Getters
+  uint32_t GetChannel() { return fChannel; }
+  ErrorType GetErrorType() { return fErrorType; }
+  uint32_t GetErrorDetails() { return fErrorDetails; }
+
+  // Print out detailed error information
+  void Print(void);
+
+private:
+  uint32_t fChannel;
+  ErrorType fErrorType;
+  uint32_t fErrorDetails;
+};
+
+#endif
+

--- a/interface/PLTError.h
+++ b/interface/PLTError.h
@@ -3,7 +3,8 @@
 
 // A very simple container class to hold information about a single
 // error reported in the data stream. There are three fields:
-// 1) channel: FED channel number that the error is in
+// 1) channel: FED channel number that the error is in (only meaningful for
+//   time out, event number error, FED trailer error, or TBM error)
 // 2) errorType: what kind of error it is
 // 3) errorDetails: more information on the error:
 //   -- for time out, the time out counter

--- a/interface/PLTEvent.h
+++ b/interface/PLTEvent.h
@@ -6,7 +6,7 @@
 #include "PLTGainCal.h"
 #include "PLTAlignment.h"
 #include "PLTTracking.h"
-
+#include "PLTError.h"
 
 #include <map>
 
@@ -99,6 +99,8 @@ class PLTEvent : public PLTTracking
 
     int GetFEDChannel(int mFec, int mFecCh, int hubId) { return fGainCal.GetFEDChannel(mFec, mFecCh, hubId); }
 
+    const std::vector<PLTError>& GetErrors(void) { return fErrors; }
+
     std::vector<int>& getDesyncChannels(void) { return fDesyncChannels; }
 
     std::string ReadableTime();
@@ -109,6 +111,7 @@ class PLTEvent : public PLTTracking
     unsigned long fEvent;
     uint32_t fTime;
     uint32_t fBX;
+    std::vector<PLTError> fErrors;
     std::vector<int> fDesyncChannels;
 
     PLTGainCal fGainCal;

--- a/src/PLTBinaryFileReader.cc
+++ b/src/PLTBinaryFileReader.cc
@@ -128,7 +128,7 @@ bool PLTBinaryFileReader::DecodeSpyDataFifo (uint32_t word, std::vector<PLTHit*>
 	  const int offsets[8] = {0,4,9,13,18,22,27,31}; // the beginning of each of the eight groups
 	  const int offset = offsets[group];
 	  for (int i=0; i<5; i++) {
-	    if (channelMask & (1 >> i)) {
+	    if (channelMask & (1 << i)) {
 	      int thisChan = offset + i + 1;
 	      Errors.push_back(PLTError(thisChan, kTimeOut, timeoutCounter));
 	    }

--- a/src/PLTError.cc
+++ b/src/PLTError.cc
@@ -1,0 +1,73 @@
+#include "PLTError.h"
+#include <iostream>
+
+PLTError::PLTError(uint32_t channel, ErrorType errorType, uint32_t errorDetails):
+  fChannel(channel), fErrorType(errorType), fErrorDetails(errorDetails) {
+}
+
+PLTError::~PLTError() {}
+
+// Print out error details for a given error.
+
+void PLTError::Print(void) {
+  switch (fErrorType) {
+
+  case kTimeOut:
+    std::cout << "Channel " << fChannel << " time out (counter: " << fErrorDetails << ")" << std::endl;
+    break;
+
+  case kEventNumberError:
+    std::cout << "Channel " << fChannel << " event number error (TBM event number: " << fErrorDetails << ")" << std::endl;
+    break;
+
+  case kNearFull:
+    std::cout << "Channel " << fChannel << " FIFO near full:";
+    if (fErrorDetails & 1) std::cout << " Ia";
+    if (fErrorDetails & (1 << 1)) std::cout << " Ib";
+    if (fErrorDetails & (1 << 2)) std::cout << " Ic";
+    if (fErrorDetails & (1 << 3)) std::cout << " Id";
+    if (fErrorDetails & (1 << 4)) std::cout << " Ie";
+
+    if (fErrorDetails & (1 << 6)) std::cout << " II";
+    if (fErrorDetails & (1 << 7)) std::cout << " L1A";
+    std::cout << std::endl;
+    break;
+
+  case kFEDTrailerError:
+    std::cout << "Channel " << fChannel << " FED trailer error:";
+    if (fErrorDetails & 1) std::cout << " data overflow";
+    if (fErrorDetails & (3 << 1)) std::cout << " FSM error " << (fErrorDetails & (3 << 1));
+    if (fErrorDetails & (1 << 3)) std::cout << " invalid # of ROCs";
+    std::cout << std::endl;
+    break;
+
+  case kTBMError:
+    std::cout << "Channel " << fChannel << " TBM error:";
+    if (fErrorDetails & 1) std::cout << " stack full";
+    if (fErrorDetails & (1 << 1)) std::cout << " precal trigger issued";
+    if (fErrorDetails & (1 << 2)) std::cout << " event counter cleared";
+    if (fErrorDetails & (1 << 3)) std::cout << " sync trigger";
+    if (fErrorDetails & (1 << 4)) std::cout << " sync trigger error";
+    if (fErrorDetails & (1 << 5)) std::cout << " ROC reset";
+    if (fErrorDetails & (1 << 6)) std::cout << " TBM reset";
+    if (fErrorDetails & (1 << 7)) std::cout << " no token pass";
+    std::cout << std::endl;
+    break;
+
+  case kUnknownError:
+    std::cout << "Channel " << fChannel << " unknown error" << std::endl;
+    break;
+
+  default:
+    std::cout << "Unknown error type" << std::endl;
+  }
+}
+
+
+
+
+
+
+
+
+

--- a/src/PLTError.cc
+++ b/src/PLTError.cc
@@ -9,7 +9,7 @@ PLTError::~PLTError() {}
 
 // Print out error details for a given error.
 
-void PLTError::Print(void) {
+void PLTError::Print(void) const {
   switch (fErrorType) {
 
   case kTimeOut:
@@ -36,7 +36,7 @@ void PLTError::Print(void) {
   case kFEDTrailerError:
     std::cout << "Channel " << fChannel << " FED trailer error:";
     if (fErrorDetails & 1) std::cout << " data overflow";
-    if (fErrorDetails & (3 << 1)) std::cout << " FSM error " << (fErrorDetails & (3 << 1));
+    if (fErrorDetails & (3 << 1)) std::cout << " FSM error " << ((fErrorDetails >> 1) & 3);
     if (fErrorDetails & (1 << 3)) std::cout << " invalid # of ROCs";
     std::cout << std::endl;
     break;
@@ -62,12 +62,3 @@ void PLTError::Print(void) {
     std::cout << "Unknown error type" << std::endl;
   }
 }
-
-
-
-
-
-
-
-
-

--- a/src/PLTError.cc
+++ b/src/PLTError.cc
@@ -21,7 +21,7 @@ void PLTError::Print(void) {
     break;
 
   case kNearFull:
-    std::cout << "Channel " << fChannel << " FIFO near full:";
+    std::cout << "FIFO near full:";
     if (fErrorDetails & 1) std::cout << " Ia";
     if (fErrorDetails & (1 << 1)) std::cout << " Ib";
     if (fErrorDetails & (1 << 2)) std::cout << " Ic";
@@ -55,7 +55,7 @@ void PLTError::Print(void) {
     break;
 
   case kUnknownError:
-    std::cout << "Channel " << fChannel << " unknown error" << std::endl;
+    std::cout << "Unknown error" << std::endl;
     break;
 
   default:

--- a/src/PLTEvent.cc
+++ b/src/PLTEvent.cc
@@ -138,7 +138,7 @@ void PLTEvent::Clear ()
   fHits.clear();
   fPlanes.clear();
   fTelescopes.clear();
-
+  fErrors.clear();
   fDesyncChannels.clear();
 }
 
@@ -268,7 +268,7 @@ int PLTEvent::GetNextEvent ()
   Clear();
 
   // The number we'll return.. number of hits, or -1 for end
-  int ret = fBinFile.ReadEventHits(fHits, fEvent, fTime, fBX, fDesyncChannels);
+  int ret = fBinFile.ReadEventHits(fHits, fErrors, fEvent, fTime, fBX, fDesyncChannels);
   if (ret < 0) {
     return ret;
   }


### PR DESCRIPTION
Added some functionality to PLTBinaryFileReader so that the error information is also available in the event information. The errors are stored as a vector of PLTError, which is a simple container class to hold the error information.